### PR TITLE
Replace deprecated js call

### DIFF
--- a/Sources/haxerecast/Recast.hx
+++ b/Sources/haxerecast/Recast.hx
@@ -17,7 +17,7 @@ class Recast {
 
 	public function new() {
 		#if js
-		hrecast = untyped __js__("(1, eval)('this').recast");
+		hrecast = js.Syntax.code("(1, eval)('this').recast");
 		#end
 	}
 


### PR DESCRIPTION
To get rid of compiler warning.